### PR TITLE
bugfix inside verseList component: appbar padding too big

### DIFF
--- a/lib/features/quran/presentation/screens/components/verses_list.dart
+++ b/lib/features/quran/presentation/screens/components/verses_list.dart
@@ -116,6 +116,7 @@ class _VersesListState extends State<VersesList> {
         }
       },
       child: SafeArea(
+        top: false,
         child: ScrollablePositionedList.separated(
           itemScrollController: _itemScrollController,
           itemPositionsListener: _itemPositionsListener,


### PR DESCRIPTION
Exception on safeArea widget at top 